### PR TITLE
use: vuejs-date(time)picker 패키지 대신 v-calendar 패키지 사용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4408,10 +4408,10 @@
         "whatwg-url": "^8.0.0"
       }
     },
-    "date-fns": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
+    "date-fns-tz": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.6.tgz",
+      "integrity": "sha512-C8q7mErvG4INw1ZwAFmPlGjEo5Sv4udjKVbTc03zpP9cu6cp5AemFzKhz0V68LGcWEtX5mJudzzg3G04emIxLA=="
     },
     "de-indent": {
       "version": "1.0.2",
@@ -8385,8 +8385,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmmirror.com/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.debounce": {
       "version": "4.0.8",
@@ -8608,11 +8607,6 @@
       "requires": {
         "yallist": "^4.0.0"
       }
-    },
-    "luxon": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.0.tgz",
-      "integrity": "sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ=="
     },
     "make-dir": {
       "version": "3.1.0",
@@ -11134,6 +11128,24 @@
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true
     },
+    "v-calendar": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/v-calendar/-/v-calendar-2.4.1.tgz",
+      "integrity": "sha512-nhzOlHM2cinv+8jIcnAx+nTo63U40szv3Ig41uLMpGK1U5sApgCP6ggigprsnlMOM5VRq1G/1B8rNHkRrLbGjw==",
+      "requires": {
+        "core-js": "^3.15.2",
+        "date-fns": "^2.22.1",
+        "date-fns-tz": "^1.1.4",
+        "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "date-fns": {
+          "version": "2.29.1",
+          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.1.tgz",
+          "integrity": "sha512-dlLD5rKaKxpFdnjrs+5azHDFOPEu4ANy/LTh04A1DTzMM7qoajmKCBc8pkKRFT41CNzw+4gQh79X5C+Jq27HAw=="
+        }
+      }
+    },
     "v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmmirror.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -11183,11 +11195,6 @@
         "@vue/compiler-sfc": "2.7.4",
         "csstype": "^3.1.0"
       }
-    },
-    "vue-datetime": {
-      "version": "1.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/vue-datetime/-/vue-datetime-1.0.0-beta.14.tgz",
-      "integrity": "sha512-n25LqldE1xryeoweohiqlxy8iUsi+UwZnKLaN4gXjk7xxGL6rUl1y/GGvkoMwJUzRKttw+QnQV4oFAYupUQdug=="
     },
     "vue-eslint-parser": {
       "version": "8.3.0",
@@ -11359,20 +11366,6 @@
       "resolved": "https://registry.npmmirror.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
-    },
-    "vuejs-datepicker": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/vuejs-datepicker/-/vuejs-datepicker-1.6.2.tgz",
-      "integrity": "sha512-PkC4vxzFBo7i6FSCUAJfnaWOx6VkKbOqxijSGHHlWxh8FIUKEZVtFychkonVWtK3iwWfhmYtqHcwsmgxefLpLQ=="
-    },
-    "vuejs-datetimepicker": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/vuejs-datetimepicker/-/vuejs-datetimepicker-1.1.13.tgz",
-      "integrity": "sha512-R7UtjXqRpqLnUk9uSiAmWXk64hFFfpoGDRiFLVGORU/ptSQRPh0KhfBwoe1ED7EeCQBAP8dXRh14n8RmfC6m1g==",
-      "requires": {
-        "date-fns": "^1.29.0",
-        "vue": "^2.3.3"
-      }
     },
     "vuex": {
       "version": "3.6.2",
@@ -11759,11 +11752,6 @@
       "resolved": "https://registry.npmmirror.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
       "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
       "dev": true
-    },
-    "weekstart": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/weekstart/-/weekstart-1.1.0.tgz",
-      "integrity": "sha512-ZO3I7c7J9nwGN1PZKZeBYAsuwWEsCOZi5T68cQoVNYrzrpp5Br0Bgi0OF4l8kH/Ez7nKfxa5mSsXjsgris3+qg=="
     },
     "whatwg-encoding": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -15,14 +15,10 @@
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "@fortawesome/vue-fontawesome": "^2.0.8",
     "core-js": "^3.8.3",
-    "luxon": "^1.28.0",
+    "v-calendar": "^2.4.1",
     "vue": "^2.6.14",
-    "vue-datetime": "^1.0.0-beta.14",
     "vue-router": "^3.5.3",
-    "vuejs-datepicker": "^1.6.2",
-    "vuejs-datetimepicker": "^1.1.13",
-    "vuex": "^3.6.2",
-    "weekstart": "^1.1.0"
+    "vuex": "^3.6.2"
   },
   "devDependencies": {
     "@babel/core": "^7.12.16",

--- a/src/main.js
+++ b/src/main.js
@@ -2,15 +2,13 @@ import Vue from 'vue';
 import App from './App.vue';
 import router from '@/routes/index';
 import store from '@/store/index';
-import { Datetime } from 'vue-datetime';
-// You need a specific loader for CSS files
-import 'vue-datetime/dist/vue-datetime.css';
+import VCalendar from 'v-calendar';
 
 Vue.config.productionTip = false;
 
-Vue.use(Datetime);
-Vue.component('dateTime', Datetime);
-
+Vue.use(VCalendar, {
+  componentPrefix: 'vc', // Use <vc-calendar /> instead of <v-calendar />
+});
 new Vue({
   render: h => h(App),
   router,


### PR DESCRIPTION
- 가게부 목록을 달력형태로도 보여주기위한 패키지를 찾던중에 v-calendar패키지를통해 datepicker,datetimepicker까지 전부 사용
- 관련 이슈: #27 