### PR TITLE
style:가게부목록이많을떄 맨 아래 navi가 겹쳐보이는문제점수정

### DIFF
--- a/src/components/common/Navigation.vue
+++ b/src/components/common/Navigation.vue
@@ -44,6 +44,7 @@ export default {
   width: 100%;
   display: flex;
   flex-wrap: nowrap;
+  z-index: 9999;
 }
 .nav__section div {
   width: 50%;


### PR DESCRIPTION
-관련이슈: #62  